### PR TITLE
read処理及びcreat処理の単体テストの実装

### DIFF
--- a/src/main/java/com/finalhomework/pokemonservice/Name.java
+++ b/src/main/java/com/finalhomework/pokemonservice/Name.java
@@ -1,5 +1,7 @@
 package com.finalhomework.pokemonservice;
 
+import java.util.Objects;
+
 public class Name {
 
     private Integer id;
@@ -37,4 +39,26 @@ public class Name {
         return type2;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Name name1 = (Name) o;
+        return Objects.equals(id, name1.id) && Objects.equals(name, name1.name) && Objects.equals(type1, name1.type1) && Objects.equals(type2, name1.type2);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, type1, type2);
+    }
+
+    @Override
+    public String toString() {
+        return "Name{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", type1='" + type1 + '\'' +
+                ", type2='" + type2 + '\'' +
+                '}';
+    }
 }

--- a/src/test/java/com/finalhomework/pokemonservice/PokemonServiceTest.java
+++ b/src/test/java/com/finalhomework/pokemonservice/PokemonServiceTest.java
@@ -1,0 +1,96 @@
+package com.finalhomework.pokemonservice;
+
+import com.finalhomework.pokemonservice.Excption.NameDuplicateException;
+import com.finalhomework.pokemonservice.Excption.PokemonNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PokemonServiceTest {
+
+    @InjectMocks
+    private PokemonService pokemonService;
+
+    @Mock
+    private PokemonMapper pokemonMapper;
+
+    @Test
+    public void すべてのポケモンを返す() {
+        List<Name> PokemonList = List.of(
+                new Name(1, "キモリ", "くさ", ""),
+                new Name(2, "ジュプトル", "くさ", ""),
+                new Name(3, "ジュカイン", "くさ", ""),
+                new Name(4, "アチャモ", "ほのお", ""),
+                new Name(5, "ワカシャモ", "ほのお", "かくとう"),
+                new Name(6, "バシャーモ", "ほのお", "かくとう"),
+                new Name(7, "ミズゴロウ", "みず", ""),
+                new Name(8, "ヌマクロー", "みず", "じめん"),
+                new Name(9, "ラグラージ", "みず", "じめん"));
+        doReturn(PokemonList).when(pokemonMapper).findAll();
+
+        List<Name> actual = pokemonService.getName(null);
+        assertThat(actual).isEqualTo(PokemonList);
+
+        verify(pokemonMapper).findAll();
+    }
+
+    @Test
+    public void 指定した頭文字のポケモンを返す() {
+        doReturn(List.of(new Name(6, "バシャーモ", "ほのお", "かくとう"))).when(pokemonMapper).findByNameStartingWith("バ");
+
+        List<Name> actual = pokemonService.getName("バ");
+        assertThat(actual).isEqualTo(List.of(new Name(6, "バシャーモ", "ほのお", "かくとう")));
+
+        verify(pokemonMapper).findByNameStartingWith("バ");
+    }
+
+    @Test
+    public void 指定したIDのポケモンを返す() {
+        doReturn(Optional.of(new Name(3, "ジュカイン", "くさ", ""))).when(pokemonMapper).findById(3);
+
+        Name actual = pokemonService.findNameById(3);
+        assertThat(actual).isEqualTo(new Name(3, "ジュカイン", "くさ", ""));
+
+        verify(pokemonMapper).findById(3);
+    }
+
+    @Test
+    public void 指定したIDが存在しない場合は例外をスローする() {
+        doReturn(Optional.empty()).when(pokemonMapper).findById(100);
+
+        assertThatThrownBy(() -> pokemonService.findNameById(100)).isInstanceOf(PokemonNotFoundException.class);
+
+        verify(pokemonMapper).findById(100);
+    }
+
+    @Test
+    public void 新しいポケモンの登録() {
+        Name newName = new Name("ポチエナ", "あく", "");
+
+        Name actual = pokemonService.insert("ポチエナ", "あく", "");
+        assertThat(actual).isEqualTo(newName);
+
+        verify(pokemonMapper).insert(newName);
+    }
+
+    @Test
+    public void 同じ名前のポケモンを登録しようとすると例外をスローする() {
+        Name newName = new Name("キモリ", "くさ", "");
+        doReturn(List.of(newName)).when(pokemonMapper).findAll();
+
+        assertThatThrownBy(() -> pokemonService.insert("キモリ", "くさ", "")).isInstanceOf(NameDuplicateException.class);
+
+        verify(pokemonMapper, never()).insert(newName);
+    }
+
+}

--- a/src/test/resources/sqlannotation/delete-names.sql
+++ b/src/test/resources/sqlannotation/delete-names.sql
@@ -1,0 +1,1 @@
+DELETE FROM pokemon;

--- a/src/test/resources/sqlannotation/insert-names.sql
+++ b/src/test/resources/sqlannotation/insert-names.sql
@@ -1,0 +1,1 @@
+INSERT INTO pokemon (name,type1,type2) VALUES ('キモリ','くさ','');


### PR DESCRIPTION
# 概要
read処理及びcreat処理の単体テストを実装しました。
# 動作確認
## read処理
全件検索
![image](https://github.com/user-attachments/assets/7a956a8d-0023-4062-a46a-745c9c5dd0c2)
頭文字の検索
![image](https://github.com/user-attachments/assets/20527303-e647-4b65-a76b-b9915b348ad2)
ID検索
![image](https://github.com/user-attachments/assets/cdb7e394-27e4-45d1-b311-00af19b22873)
IDがなかった場合の例外処理
![image](https://github.com/user-attachments/assets/ab3b72b7-c2b4-4959-ba9f-7900ada6e44e)
## creat処理
登録処理
![image](https://github.com/user-attachments/assets/11fd9fa9-4136-4dc0-ae8d-8a30b962b44d)
重複する名前を登録しようとしたときの例外処理
![image](https://github.com/user-attachments/assets/ec42a00b-9f37-404c-bf9f-f3e6c20c51d0)